### PR TITLE
feat: Update CD pipeline with Docker build and push

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -16,5 +16,8 @@ jobs:
         with:
           go-version: "1.22"
 
-      - name: Build Go Binary
+      - name: Build Production Binary
         run: ./scripts/buildprod.sh
+
+      - name: Build Docker image and push to GCP Artifact Registry
+        run: gcloud builds submit --tag us-central1-docker.pkg.dev/notely-431916/notely-ar-repo/timenglesf/notely:latest .


### PR DESCRIPTION
This commit updates the Continuous Deployment (CD) pipeline by replacing the Go binary build step with a Docker image build step. Additionally, it introduces a new step to push the built Docker image to the Google Cloud Platform (GCP) Artifact Registry. This modification is crucial for deploying the application in a containerized environment.