### PR TITLE
fix: Specify project in GCP Docker image push command

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -20,4 +20,4 @@ jobs:
         run: ./scripts/buildprod.sh
 
       - name: Build Docker image and push to GCP Artifact Registry
-        run: gcloud builds submit --tag us-central1-docker.pkg.dev/notely-431916/notely-ar-repo/timenglesf/notely:latest .
+        run: gcloud builds submit --tag us-central1-docker.pkg.dev/notely-431916/notely-ar-repo/timenglesf/notely:latest --project notely-431916 .


### PR DESCRIPTION
This commit modifies the command used to push Docker images to the Google Cloud Platform (GCP) Artifact Registry in the Continuous Deployment (CD) pipeline. The project ID is now explicitly specified in the command, ensuring that the images are pushed to the correct GCP project.