### PR TITLE
feat: add GCP auth and setup in CD workflow

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -19,5 +19,16 @@ jobs:
       - name: Build Production Binary
         run: ./scripts/buildprod.sh
 
-      - name: Build Docker image and push to GCP Artifact Registry
-        run: gcloud builds submit --tag us-central1-docker.pkg.dev/notely-431916/notely-ar-repo/timenglesf/notely:latest --project notely-431916 .
+      - id: auth
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GCP_CREDENTIALS }}
+
+      - name: Setup GCP SDK
+        uses: "google-github-actions/setup-gcloud@v2"
+
+      - name: Use gcloud cli
+        run: gcloud info
+
+      - name: Build & Push Docker image and push to GCP Artifact Registry
+        run: gcloud builds submit --tag us-central1-docker.pkg.dev/notely-431916/notely-ar-repo/timenglesf/notely:latest .


### PR DESCRIPTION
This commit introduces the use of google-github-actions for authentication and setup of the GCP SDK in the Continuous Deployment workflow. This change ensures that the GCP credentials are securely used and the GCP SDK is properly set up before building and pushing the Docker image to the GCP Artifact Registry.